### PR TITLE
Update AdSenseUtil.server.ts

### DIFF
--- a/client/common/utils/AdSenseUtil.server.ts
+++ b/client/common/utils/AdSenseUtil.server.ts
@@ -13,7 +13,7 @@ export default class AdSenseUtil {
    */
   public static async getAdSenseConfig(enableAutoAds: boolean = true): Promise<AdsenseConfig | null> {
     try {
-      const publisherId = await SecretsManagerUtil.getSecretValue('GoogleAdSense', 'PUBLISHER_ID');
+      const publisherId = await SecretsManagerUtil.getSecretValue('GoogleAdSense', 'PUBLISHER_ID', true);
       
       return {
         publisherId,


### PR DESCRIPTION
This pull request makes a small update to how AdSense configuration secrets are fetched. The method now explicitly requests a decrypted value when retrieving the `PUBLISHER_ID` from the secrets manager.

* Updated `getAdSenseConfig` in `AdSenseUtil.server.ts` to fetch the `PUBLISHER_ID` secret in decrypted form by passing `true` to `getSecretValue`.